### PR TITLE
Add cloudwatch rule for efs_handle_delayed_submission_sameday

### DIFF
--- a/terraform/groups/configurable-api-caller/main.tf
+++ b/terraform/groups/configurable-api-caller/main.tf
@@ -144,7 +144,7 @@ resource "aws_cloudwatch_event_rule" "call_api_caller_lambda_efs_handle_delayed_
   count               = var.deploy_to == "development" ? 1 : 0
   name                = "call_api_caller_lambda_efs_handle_delayed_submission_sameday"
   description         = "Cloudwatch event to call ${aws_lambda_function.configurable_api_lambda.function_name} lambda routinely"
-  schedule_expression = "rate(15 minute)"
+  schedule_expression = "cron(*/15 7-17 * * MON-FRI *)"
 }
 
 resource "aws_cloudwatch_event_target" "event_target_api_caller_efs_handle_delayed_submission_sameday" {

--- a/terraform/groups/configurable-api-caller/main.tf
+++ b/terraform/groups/configurable-api-caller/main.tf
@@ -140,6 +140,30 @@ resource "aws_lambda_permission" "allow_cloudwatch_dissolutions_rebel1" {
   source_arn    = aws_cloudwatch_event_rule.call_api_caller_lambda_dissolutions_rebel1[0].arn
 }
 
+resource "aws_cloudwatch_event_rule" "call_api_caller_lambda_efs_handle_delayed_submission_sameday" {
+  count               = var.deploy_to == "development" ? 1 : 0
+  name                = "call_api_caller_lambda_efs_handle_delayed_submission_sameday"
+  description         = "Cloudwatch event to call ${aws_lambda_function.configurable_api_lambda.function_name} lambda routinely"
+  schedule_expression = "rate(15 minute)"
+}
+
+resource "aws_cloudwatch_event_target" "event_target_api_caller_efs_handle_delayed_submission_sameday" {
+  count     = var.deploy_to == "development" ? 1 : 0
+  target_id = aws_cloudwatch_event_rule.call_api_caller_lambda_efs_handle_delayed_submission_sameday.id
+  rule      = aws_cloudwatch_event_rule.call_api_caller_lambda_efs_handle_delayed_submission_sameday.name
+  arn       = aws_lambda_function.configurable_api_lambda.arn
+  input     = file("profiles/${var.aws_profile}/efs_handle_delayed_submission_sameday.json")
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_efs_handle_delayed_submission_sameday" {
+  count         = var.deploy_to == "development" ? 1 : 0
+  statement_id  = "AllowExecutionFromCloudWatchEFS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.configurable_api_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.call_api_caller_lambda_efs_handle_delayed_submission_sameday.arn
+}
+
 // VPC
 
 data "terraform_remote_state" "applications_vpc" {

--- a/terraform/groups/configurable-api-caller/main.tf
+++ b/terraform/groups/configurable-api-caller/main.tf
@@ -143,7 +143,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_dissolutions_rebel1" {
 resource "aws_cloudwatch_event_rule" "call_api_caller_lambda_efs_handle_delayed_submission_sameday" {
   count               = var.deploy_to == "development" ? 1 : 0
   name                = "call_api_caller_lambda_efs_handle_delayed_submission_sameday"
-  description         = "Cloudwatch event to call ${aws_lambda_function.configurable_api_lambda.function_name} lambda routinely"
+  description         = "Cloudwatch event to call ${aws_lambda_function.configurable_api_lambda.function_name} lambda routinely, which calls EFS API to check for any delayed same day submissions"
   schedule_expression = "cron(*/15 7-17 * * MON-FRI *)"
 }
 

--- a/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/efs_handle_delayed_submission_sameday.json
+++ b/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/efs_handle_delayed_submission_sameday.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "api.cidev.aws.chdev.org",
+    "API_KEY_REF": "/api-caller/secure-key-test",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/handle-delayed-submissions/?service=SAMEDAY",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/efs_handle_delayed_submission_sameday.json
+++ b/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/efs_handle_delayed_submission_sameday.json
@@ -1,6 +1,6 @@
 {
     "API_HOST": "api.companieshouse.gov.uk",
-    "API_KEY_REF": "/api-caller/secure-key-test",
+    "API_KEY_REF": "/api-caller/secure-application-key",
     "IS_SSL": true,
     "HEADERS": {
       "headers": {

--- a/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/efs_handle_delayed_submission_sameday.json
+++ b/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/efs_handle_delayed_submission_sameday.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "api.companieshouse.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-key-test",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/handle-delayed-submissions/?service=SAMEDAY",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/efs_handle_delayed_submission_sameday.json
+++ b/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/efs_handle_delayed_submission_sameday.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api-staging-aws.companieshouse.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-key-test",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/handle-delayed-submissions/?service=SAMEDAY",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/efs_handle_delayed_submission_sameday.json
+++ b/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/efs_handle_delayed_submission_sameday.json
@@ -1,6 +1,6 @@
 {
     "API_HOST": "internal-api-staging-aws.companieshouse.gov.uk",
-    "API_KEY_REF": "/api-caller/secure-key-test",
+    "API_KEY_REF": "/api-caller/secure-application-key",
     "IS_SSL": true,
     "HEADERS": {
       "headers": {


### PR DESCRIPTION
New EFS API endpoint created that needs to be called routinely.

Check:
- I copied the dissolution rule/target/permission, and made substitutions.  I don't speak 'terraform'!
- cron expression - Mon-Fri, 7am-5pm, every 15 mins
- endpoint as per https://github.com/companieshouse/efs-submission-api/pull/76
- done for cidev, staging and live

NB - there is an existing cloudwatch rule for `events/handle-delayed-submissions` but this must have been set up manually, and this PR doesn't include it.
- I could add it here or perhaps best to do it separately if needed??

BI-8232
BI-8467