### PR TITLE
Add 2 EFS calls to terraform and amend the cron frequency

### DIFF
--- a/terraform/groups/configurable-api-caller/main.tf
+++ b/terraform/groups/configurable-api-caller/main.tf
@@ -161,6 +161,48 @@ resource "aws_lambda_permission" "allow_cloudwatch_efs_handle_delayed_submission
   source_arn    = aws_cloudwatch_event_rule.call_api_caller_lambda_efs_handle_delayed_submission_sameday.arn
 }
 
+resource "aws_cloudwatch_event_rule" "efs_queue_files" {
+  name                = "efs_queue_files"
+  description         = "Uses ${aws_lambda_function.configurable_api_lambda.function_name} lambda to call EFS Submission API to queue files in EFS document processor"
+  schedule_expression = "cron(* * * * * *)"
+}
+
+resource "aws_cloudwatch_event_target" "event_target_efs_queue_files" {
+  target_id = aws_cloudwatch_event_rule.efs_queue_files.id
+  rule      = aws_cloudwatch_event_rule.efs_queue_files.name
+  arn       = aws_lambda_function.configurable_api_lambda.arn
+  input     = file("profiles/${var.aws_profile}/efs_queue_files.json")
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_efs_queue_files" {
+  statement_id  = "AllowExecutionFromCloudWatchEFS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.configurable_api_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.efs_queue_files.arn
+}
+
+resource "aws_cloudwatch_event_rule" "efs_submit_files_to_fes" {
+  name                = "efs_submit_files_to_fes"
+  description         = "Uses ${aws_lambda_function.configurable_api_lambda.function_name} lambda to call EFS Submission API to submit files to FES"
+  schedule_expression = "cron(* * * * * *)"
+}
+
+resource "aws_cloudwatch_event_target" "event_target_efs_submit_files_to_fes" {
+  target_id = aws_cloudwatch_event_rule.efs_submit_files_to_fes.id
+  rule      = aws_cloudwatch_event_rule.efs_submit_files_to_fes.name
+  arn       = aws_lambda_function.configurable_api_lambda.arn
+  input     = file("profiles/${var.aws_profile}/efs_submit_files_to_fes.json")
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_efs_submit_files_to_fes" {
+  statement_id  = "AllowExecutionFromCloudWatchEFS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.configurable_api_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.efs_submit_files_to_fes.arn
+}
+
 // VPC
 
 data "terraform_remote_state" "applications_vpc" {

--- a/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/efs_queue_files.json
+++ b/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/efs_queue_files.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internalapi.cidev.aws.chdev.org",
+    "API_KEY_REF": "/api-caller/secure-key-test",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/queue-files",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/efs_submit_files_to_fes.json
+++ b/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/efs_submit_files_to_fes.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internalapi.cidev.aws.chdev.org",
+    "API_KEY_REF": "/api-caller/secure-key-test",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/submit-files-to-fes",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/efs_queue_files.json
+++ b/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/efs_queue_files.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api.company-information.service.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-application-key",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/queue-files",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/efs_submit_files_to_fes.json
+++ b/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/efs_submit_files_to_fes.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api.company-information.service.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-application-key",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/submit-files-to-fes",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/efs_queue_files.json
+++ b/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/efs_queue_files.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api-staging.company-information.service.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-application-key",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/queue-files",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/efs_submit_files_to_fes.json
+++ b/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/efs_submit_files_to_fes.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api-staging.company-information.service.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-application-key",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/submit-files-to-fes",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}


### PR DESCRIPTION
- `efs-submission-api/events/queue-files`
- `efs-submission-api/events/submit-files-to-fes`
- they are already present in AWS but requirement to increase frequency from 5 mins to every minute

BI-8756

These are to replace these existing rules:
in cidev:
cidev-efs-call-submit-to-fes-endpoint
cidev-efs-submission-routine-call

in staging:
efs-email-submission-routine-call
efs-deadq-email-submission-routine-call

in live:
will have to find this out with Support or Devops