### PR TITLE
Adding 3 EFS rules to terraform that are already configured in live

### DIFF
--- a/terraform/groups/configurable-api-caller/main.tf
+++ b/terraform/groups/configurable-api-caller/main.tf
@@ -164,6 +164,26 @@ resource "aws_lambda_permission" "allow_cloudwatch_dissolutions_phoenix1" {
   source_arn    = aws_cloudwatch_event_rule.call_api_caller_lambda_dissolutions_phoenix1[0].arn
 }
 
+resource "aws_cloudwatch_event_rule" "call_api_caller_lambda_efs_handle_delayed_submission" {
+  name                = "call_api_caller_lambda_efs_handle_delayed_submission"
+  description         = "Cloudwatch event to call ${aws_lambda_function.configurable_api_lambda.function_name} lambda daily, which calls EFS API to check for any delayed submissions"
+  schedule_expression = "cron(0 08 ? * MON-FRI *)"
+}
+
+resource "aws_cloudwatch_event_target" "event_target_api_caller_efs_handle_delayed_submission" {
+  target_id = aws_cloudwatch_event_rule.call_api_caller_lambda_efs_handle_delayed_submission.id
+  rule      = aws_cloudwatch_event_rule.call_api_caller_lambda_efs_handle_delayed_submission.name
+  arn       = aws_lambda_function.configurable_api_lambda.arn
+  input     = file("profiles/${var.aws_profile}/common-${var.aws_region}/efs_handle_delayed_submission.json")
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_efs_handle_delayed_submission" {
+  statement_id  = "AllowExecutionFromCloudWatchEFSDelayedSubmission"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.configurable_api_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.call_api_caller_lambda_efs_handle_delayed_submission.arn
+}
 
 resource "aws_cloudwatch_event_rule" "call_api_caller_lambda_efs_handle_delayed_submission_sameday" {
   name                = "call_api_caller_lambda_efs_handle_delayed_submission_sameday"
@@ -226,6 +246,48 @@ resource "aws_lambda_permission" "allow_cloudwatch_efs_submit_files_to_fes" {
   function_name = aws_lambda_function.configurable_api_lambda.function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.efs_submit_files_to_fes.arn
+}
+
+resource "aws_cloudwatch_event_rule" "efs_payment_report_finance" {
+  name                = "efs_payment_report_finance"
+  description         = "Cloudwatch event to call ${aws_lambda_function.configurable_api_lambda.function_name} lambda daily, which calls EFS API to send payment report to finance"
+  schedule_expression = "cron(0 02 ? * * *)"
+}
+
+resource "aws_cloudwatch_event_target" "event_target_efs_payment_report_finance" {
+  target_id = aws_cloudwatch_event_rule.efs_payment_report_finance.id
+  rule      = aws_cloudwatch_event_rule.efs_payment_report_finance.name
+  arn       = aws_lambda_function.configurable_api_lambda.arn
+  input     = file("profiles/${var.aws_profile}/common-${var.aws_region}/efs_payment_report_finance.json")
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_efs_payment_report_finance" {
+  statement_id  = "AllowExecutionFromCloudWatchEFSPaymentReportFinance"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.configurable_api_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.efs_payment_report_finance.arn
+}
+
+resource "aws_cloudwatch_event_rule" "efs_payment_report_scotland" {
+  name                = "efs_payment_report_scotland"
+  description         = "Cloudwatch event to call ${aws_lambda_function.configurable_api_lambda.function_name} lambda daily, which calls EFS API to send payment report to scotland"
+  schedule_expression = "cron(0 02 ? * * *)"
+}
+
+resource "aws_cloudwatch_event_target" "event_target_efs_payment_report_scotland" {
+  target_id = aws_cloudwatch_event_rule.efs_payment_report_scotland.id
+  rule      = aws_cloudwatch_event_rule.efs_payment_report_scotland.name
+  arn       = aws_lambda_function.configurable_api_lambda.arn
+  input     = file("profiles/${var.aws_profile}/common-${var.aws_region}/efs_payment_report_scotland.json")
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_efs_payment_report_finance" {
+  statement_id  = "AllowExecutionFromCloudWatchEFSPaymentReportScotland"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.configurable_api_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.efs_payment_report_scotland.arn
 }
 
 // VPC

--- a/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/common-eu-west-2/efs_handle_delayed_submission.json
+++ b/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/common-eu-west-2/efs_handle_delayed_submission.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internalapi.cidev.aws.chdev.org",
+    "API_KEY_REF": "/api-caller/secure-key-test",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/handle-delayed-submissions",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/common-eu-west-2/efs_payment_report_finance.json
+++ b/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/common-eu-west-2/efs_payment_report_finance.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internalapi.cidev.aws.chdev.org",
+    "API_KEY_REF": "/api-caller/secure-key-test",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/payment-reports/finance",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/common-eu-west-2/efs_payment_report_scotland.json
+++ b/terraform/groups/configurable-api-caller/profiles/development-eu-west-2/common-eu-west-2/efs_payment_report_scotland.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internalapi.cidev.aws.chdev.org",
+    "API_KEY_REF": "/api-caller/secure-key-test",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/payment-reports/scotland",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/common-eu-west-2/efs_handle_delayed_submission.json
+++ b/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/common-eu-west-2/efs_handle_delayed_submission.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api.company-information.service.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-application-key",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/handle-delayed-submissions",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/common-eu-west-2/efs_payment_report_finance.json
+++ b/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/common-eu-west-2/efs_payment_report_finance.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api.company-information.service.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-application-key",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/payment-reports/finance",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/common-eu-west-2/efs_payment_report_scotland.json
+++ b/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/common-eu-west-2/efs_payment_report_scotland.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api.company-information.service.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-application-key",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/payment-reports/scotland",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/common-eu-west-2/efs_handle_delayed_submission.json
+++ b/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/common-eu-west-2/efs_handle_delayed_submission.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api-staging.company-information.service.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-application-key",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/events/handle-delayed-submissions",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/common-eu-west-2/efs_payment_report_finance.json
+++ b/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/common-eu-west-2/efs_payment_report_finance.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api-staging.company-information.service.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-application-key",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/payment-reports/finance",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/common-eu-west-2/efs_payment_report_scotland.json
+++ b/terraform/groups/configurable-api-caller/profiles/staging-eu-west-2/common-eu-west-2/efs_payment_report_scotland.json
@@ -1,0 +1,13 @@
+{
+    "API_HOST": "internal-api-staging.company-information.service.gov.uk",
+    "API_KEY_REF": "/api-caller/secure-application-key",
+    "IS_SSL": true,
+    "HEADERS": {
+      "headers": {
+        "Authorization": ""
+      }
+    },
+    "ENDPOINT": "/efs-submission-api/payment-reports/scotland",
+    "REGION": "eu-west-2",
+    "HTTP_VERB": "POST"
+}


### PR DESCRIPTION
There is a page in Confluence for 'Event Rules for configurable-api-caller' which details what is live and then what is / is not included in this terraform

BI-9335