### PR TITLE
Point account_validator to ecs

### DIFF
--- a/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/common-eu-west-2/account_validator_cleanup_submissions.json
+++ b/terraform/groups/configurable-api-caller/profiles/live-eu-west-2/common-eu-west-2/account_validator_cleanup_submissions.json
@@ -1,5 +1,5 @@
 {
-    "API_HOST": "internal-api.company-information.service.gov.uk",
+    "API_HOST": "internal-api.companieshouse.gov.uk",
     "API_KEY_REF": "/api-caller/secure-application-key",
     "IS_SSL": true,
     "HEADERS": {


### PR DESCRIPTION
Change the API_HOST to point at `ECS_ALB_INTERNAL_API_URL` so that the requests go to the correct `account-validator-api` in ECS.

Resolves: [AOAF-690](https://companieshouse.atlassian.net/browse/AOAF-690)

[AOAF-690]: https://companieshouse.atlassian.net/browse/AOAF-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ