### PR TITLE
Create config for rules existing in environments but not held in config

### DIFF
--- a/terraform/groups/configurable-api-caller/data.tf
+++ b/terraform/groups/configurable-api-caller/data.tf
@@ -78,6 +78,18 @@ data "local_file" "account_validator_cleanup_submissions" {
   filename = "${local.json_folder}/account_validator_cleanup_submissions.json"
 }
 
+data "local_file" "efs_call_finance_payment_reports_endpoint" {
+  filename = "${local.json_folder}/efs_call_finance_payment_reports_endpoint.json"
+}
+
+data "local_file" "efs_call_scotland_payment_report_endpoint" {
+  filename = "${local.json_folder}/efs_call_scotland_payment_report_endpoint.json"
+}
+
+data "local_file" "efs_delayed_submission_call" {
+  filename = "${local.json_folder}/efs_delayed_submission_call.json"
+}
+
 data "local_file" "dissolutions_submit_rebel1" {
   count = var.aws_account == "development-eu-west-2" ? 1 : 0
 

--- a/terraform/groups/configurable-api-caller/input_json/development-eu-west-2/efs_call_finance_payment_reports_endpoint.json
+++ b/terraform/groups/configurable-api-caller/input_json/development-eu-west-2/efs_call_finance_payment_reports_endpoint.json
@@ -1,0 +1,14 @@
+{
+  "API_HOST": "internalapi.cidev.aws.chdev.org",
+  "API_KEY_REF": "/api-caller/secure-key-test",
+  "IS_SSL": true,
+  "HEADERS": {
+    "headers": {
+      "Authorization": "",
+      "Content-Type": "application/json"
+    }
+  },
+  "ENDPOINT": "/efs-submission-api/payment-reports/finance",
+  "REGION": "eu-west-2",
+  "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/input_json/development-eu-west-2/efs_call_scotland_payment_report_endpoint.json
+++ b/terraform/groups/configurable-api-caller/input_json/development-eu-west-2/efs_call_scotland_payment_report_endpoint.json
@@ -1,0 +1,14 @@
+{
+  "API_HOST": "internalapi.cidev.aws.chdev.org",
+  "API_KEY_REF": "/api-caller/secure-key-test",
+  "IS_SSL": true,
+  "HEADERS": {
+    "headers": {
+      "Authorization": "",
+      "Content-Type": "application/json"
+    }
+  },
+  "ENDPOINT": "/efs-submission-api/payment-reports/scotland",
+  "REGION": "eu-west-2",
+  "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/input_json/development-eu-west-2/efs_delayed_submission_call.json
+++ b/terraform/groups/configurable-api-caller/input_json/development-eu-west-2/efs_delayed_submission_call.json
@@ -1,0 +1,14 @@
+{
+  "API_HOST": "internalapi.cidev.aws.chdev.org",
+  "API_KEY_REF": "/api-caller/secure-key-test",
+  "IS_SSL": true,
+  "HEADERS": {
+    "headers": {
+      "Authorization": "",
+      "Content-Type": "application/json"
+    }
+  },
+  "ENDPOINT": "/efs-submission-api/events/handle-delayed-submissions",
+  "REGION": "eu-west-2",
+  "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/input_json/live-eu-west-2/efs_call_finance_payment_reports_endpoint.json
+++ b/terraform/groups/configurable-api-caller/input_json/live-eu-west-2/efs_call_finance_payment_reports_endpoint.json
@@ -1,0 +1,14 @@
+{
+  "API_HOST": "internal-api.companieshouse.gov.uk",
+  "API_KEY_REF": "/api-caller/efs-submission-key",
+  "IS_SSL": true,
+  "HEADERS": {
+    "headers": {
+      "Authorization": "",
+      "Content-Type": "application/json"
+    }
+  },
+  "ENDPOINT": "/efs-submission-api/payment-reports/finance",
+  "REGION": "eu-west-2",
+  "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/input_json/live-eu-west-2/efs_call_scotland_payment_report_endpoint.json
+++ b/terraform/groups/configurable-api-caller/input_json/live-eu-west-2/efs_call_scotland_payment_report_endpoint.json
@@ -1,0 +1,14 @@
+{
+  "API_HOST": "internal-api.companieshouse.gov.uk",
+  "API_KEY_REF": "/api-caller/efs-submission-key",
+  "IS_SSL": true,
+  "HEADERS": {
+    "headers": {
+      "Authorization": "",
+      "Content-Type": "application/json"
+    }
+  },
+  "ENDPOINT": "/efs-submission-api/payment-reports/scotland",
+  "REGION": "eu-west-2",
+  "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/input_json/live-eu-west-2/efs_delayed_submission_call.json
+++ b/terraform/groups/configurable-api-caller/input_json/live-eu-west-2/efs_delayed_submission_call.json
@@ -1,0 +1,14 @@
+{
+  "API_HOST": "internal-api.companieshouse.gov.uk",
+  "API_KEY_REF": "/api-caller/efs-submission-key",
+  "IS_SSL": true,
+  "HEADERS": {
+    "headers": {
+      "Authorization": "",
+      "Content-Type": "application/json"
+    }
+  },
+  "ENDPOINT": "/efs-submission-api/events/handle-delayed-submissions",
+  "REGION": "eu-west-2",
+  "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/input_json/staging-eu-west-2/efs_call_finance_payment_reports_endpoint.json
+++ b/terraform/groups/configurable-api-caller/input_json/staging-eu-west-2/efs_call_finance_payment_reports_endpoint.json
@@ -1,0 +1,14 @@
+{
+  "API_HOST": "internal-api-staging.company-information.service.gov.uk",
+  "API_KEY_REF": "/api-caller/secure-application-key",
+  "IS_SSL": true,
+  "HEADERS": {
+    "headers": {
+      "Authorization": "",
+      "Content-Type": "application/json"
+    }
+  },
+  "ENDPOINT": "/efs-submission-api/payment-reports/finance",
+  "REGION": "eu-west-2",
+  "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/input_json/staging-eu-west-2/efs_call_scotland_payment_report_endpoint.json
+++ b/terraform/groups/configurable-api-caller/input_json/staging-eu-west-2/efs_call_scotland_payment_report_endpoint.json
@@ -1,0 +1,14 @@
+{
+  "API_HOST": "internal-api-staging.company-information.service.gov.uk",
+  "API_KEY_REF": "/api-caller/secure-application-key",
+  "IS_SSL": true,
+  "HEADERS": {
+    "headers": {
+      "Authorization": "",
+      "Content-Type": "application/json"
+    }
+  },
+  "ENDPOINT": "/efs-submission-api/payment-reports/scotland",
+  "REGION": "eu-west-2",
+  "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/input_json/staging-eu-west-2/efs_delayed_submission_call.json
+++ b/terraform/groups/configurable-api-caller/input_json/staging-eu-west-2/efs_delayed_submission_call.json
@@ -1,0 +1,14 @@
+{
+  "API_HOST": "internal-api-staging.company-information.service.gov.uk",
+  "API_KEY_REF": "/api-caller/secure-application-key",
+  "IS_SSL": true,
+  "HEADERS": {
+    "headers": {
+      "Authorization": "",
+      "Content-Type": "application/json"
+    }
+  },
+  "ENDPOINT": "/efs-submission-api/events/handle-delayed-submissions",
+  "REGION": "eu-west-2",
+  "HTTP_VERB": "POST"
+}

--- a/terraform/groups/configurable-api-caller/locals.tf
+++ b/terraform/groups/configurable-api-caller/locals.tf
@@ -60,6 +60,24 @@ locals {
       description         = "Cloudwatch event to call ${module.lambda.lambda_function_name} lambda at 2am everyday (7pm in dev environments)"
       schedule_expression = var.cron_account_validator_cleanup_submissions
       target_input        = data.local_file.account_validator_cleanup_submissions.content
+    },
+    {
+      name                = "efs-call-finance-payment-reports-endpoint"
+      description         = "Cloudwatch event to call ${module.lambda.lambda_function_name} lambda routinely on main efs payment endpoint"
+      schedule_expression = var.cron_efs_call_finance_payment_reports_endpoint
+      target_input        = data.local_file.efs_call_finance_payment_reports_endpoint.content
+    },
+    {
+      name                = "efs-call-scotland-payment-report-endpoint"
+      description         = "Cloudwatch event to call ${module.lambda.lambda_function_name} lambda routinely on scotland efs payment endpoint"
+      schedule_expression = var.cron_efs_call_scotland_payment_report_endpoint
+      target_input        = data.local_file.efs_call_scotland_payment_report_endpoint.content
+    },
+    {
+      name                = "efs-delayed-submission-call"
+      description         = "Cloudwatch event to call ${module.lambda.lambda_function_name} lambda routinely for delayed efs submissions"
+      schedule_expression = var.cron_efs_delayed_submission_call
+      target_input        = data.local_file.efs_delayed_submission_call.content
     }
   ]
 

--- a/terraform/groups/configurable-api-caller/variables.tf
+++ b/terraform/groups/configurable-api-caller/variables.tf
@@ -64,3 +64,21 @@ variable "cron_account_validator_cleanup_submissions" {
   description = "The cron string for the account validator cleanup submission cloudwatch event rule."
   type        = string
 }
+
+variable "cron_efs_call_finance_payment_reports_endpoint" {
+  description = "The cron string for the EFS call finance payment reports endpoint cloudwatch event rule."
+  type        = string
+  default     = "cron(0 2 ? * * *)"
+}
+
+variable "cron_efs_call_scotland_payment_report_endpoint" {
+  description = "The cron string for the EFS call scotland payment report endpoint cloudwatch event rule."
+  type        = string
+  default     = "cron(0 2 ? * * *)"
+}
+
+variable "cron_efs_delayed_submission_call" {
+  description = "The cron string for the EFS delayed submission call cloudwatch event rule."
+  type        = string
+  default     = "cron(0 8 ? * MON-FRI *)"
+}


### PR DESCRIPTION
Creates rule definitions for manually managed rules.

Rules will need to be imported to state ahead of running into environment

This change will enable 2 payment rules currently disabled in dev, tcats have signed off on this

